### PR TITLE
actually use path to the boost library

### DIFF
--- a/library/Makefile.am
+++ b/library/Makefile.am
@@ -6,5 +6,5 @@ libuatraits_la_SOURCES = detector.cpp detector_helper.cpp \
 
 AM_CXXFLAGS = -pthread
 AM_CPPFLAGS = -I${top_srcdir}/include -I${topc_srcdir}/config \
-	@XML_CPPFLAGS@ @PCRE_CFLAGS@
+	@XML_CPPFLAGS@ @PCRE_CFLAGS@ @BOOST_CPPFLAGS@
 AM_LDFLAGS = @XML_LIBS@ @PCRE_LIBS@

--- a/perl/Makefile.PL.in
+++ b/perl/Makefile.PL.in
@@ -15,7 +15,7 @@ WriteMakefile(
        AUTHOR         => 'Oleg Obolensky <highpower@yandex-team.ru>') : ()),
     LIBS              => ['-L../library/.libs/ @XML_LIBS@ @PCRE_LIBS@ -luatraits'],
     DEFINE            => '',
-    INC               => '-I. -I../include -I../config @XML_CPPFLAGS@ @PCRE_CFLAGS@',
+    INC               => '-I. -I../include -I../config @XML_CPPFLAGS@ @PCRE_CFLAGS@ @BOOST_CPPFLAGS@',
 	CC                => 'g++',
 	LD                => 'g++',
 	XSOPT             => '-C++',


### PR DESCRIPTION
Value of --with-boost-prefix was never actually used.
